### PR TITLE
I updated the drupal-org.make file to fix the videojs download location

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -114,7 +114,7 @@ projects[omega][version] = 3.0
 ;videojs
 libraries[video-js][type] = "libraries"
 libraries[video-js][download][type] = "get"
-libraries[video-js][download][url] = "http://videojs.com/downloads/video-js-2.0.2.zip"
+libraries[video-js][download][url] = "https://github.com/downloads/zencoder/video-js/video-js-3.0.7.zip"
 
 ;ckeditor
 libraries[ckeditor][type] = "libraries"


### PR DESCRIPTION
I figured out how to do this on Bitbucket the other day and wanted to try it out on Github.

I was trying to install the Octopus Video installation profile using the make file found on octopusvideo.org and the install kept failing because the Videojs library couldn't be found. It seems that they started using Github and moved their downloads off their website. 

I have updated the drupal-org.make file to download the latest version of Videojs from their Github repo currently. I am not sure if this will break things as it is a different major version 3.x, but figured it was better than no download at all, which is breaking the make file process. Hopefully this allows me to get the make file to complete properly so I can test out this useful looking install profile.

Thanks,

Jason
